### PR TITLE
Fix `DotEnv` logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ $ mix deps.get
 Set up the database:
 
 ```bash
+$ mix ecto.create
 $ mix ecto.migrate
+```
+
+Define the environment variables:
+
+```bash
+$ cp .env.sample .env
 ```
 
 Start the Phoenix server:


### PR DESCRIPTION
### Description

These changes:
- fix errors in the `DotEnv` logic seen when `.env` file doesn't exist as well as when the target key is not found.
- update the README to enhance the Getting Started instructions.
