### PR TITLE
Fix Safari audio player current time bug

### DIFF
--- a/src/components/AudioPlayer.vue
+++ b/src/components/AudioPlayer.vue
@@ -21,6 +21,7 @@
         :src="item.mediaUrl"
         preload="auto"
         @canplay="setCurrentTime"
+        @pause="postCurrentTime"
       >
         Your browser does not support the
         <code>audio</code> element.
@@ -92,12 +93,6 @@ export default {
 
       audioElement.playbackRate = this.playbackRate;
     }
-  },
-  mounted() {
-    const audioElement = this.$refs.audioRef;
-    if (!audioElement) return;
-
-    audioElement.addEventListener("pause", this.postCurrentTime);
   },
   beforeDestroy() {
     const audioElement = this.$refs.audioRef;

--- a/src/components/AudioPlayer.vue
+++ b/src/components/AudioPlayer.vue
@@ -15,7 +15,13 @@
     </button>
 
     <figure>
-      <audio ref="audioRef" controls :src="item.mediaUrl" preload="auto">
+      <audio
+        ref="audioRef"
+        controls
+        :src="item.mediaUrl"
+        preload="auto"
+        @canplay="setCurrentTime"
+      >
         Your browser does not support the
         <code>audio</code> element.
       </audio>
@@ -50,6 +56,11 @@ export default {
       put("/item", { items: [item] }).catch(() => {
         console.log("Error saving current playback time...");
       });
+    },
+    setCurrentTime() {
+      const audioElement = this.$refs.audioRef;
+      if (!audioElement || !this.item.currentTime) return;
+      audioElement.currentTime = this.item.currentTime;
     },
     handleRewind() {
       const audioElement = this.$refs.audioRef;
@@ -86,14 +97,13 @@ export default {
     const audioElement = this.$refs.audioRef;
     if (!audioElement) return;
 
-    if (this.item.currentTime) audioElement.currentTime = this.item.currentTime;
-
     audioElement.addEventListener("pause", this.postCurrentTime);
   },
   beforeDestroy() {
     const audioElement = this.$refs.audioRef;
     if (!audioElement) return;
 
+    audioElement.removeEventListener("canplay", this.postCurrentTime);
     audioElement.removeEventListener("pause", this.postCurrentTime);
   }
 };

--- a/src/mixins/mobileHtmlMixin.vue
+++ b/src/mixins/mobileHtmlMixin.vue
@@ -25,7 +25,6 @@ export default {
     });
 
     window.setTimeout(() => {
-      console.log(this.$refs.description);
       if (this.windowWidth < MOBILE_BREAKPOINT && this.$refs.description)
         addMaxWidth(this.$refs.description);
     }, 1000);


### PR DESCRIPTION
### Description

These changes:
- fix a bug where the audio player current time wasn't being loaded properly on Safari
- refactor `AudioPlayer` code to remove `mount` lifecycle hook in favor of template event handler definition
- remove a `console.log` statement