### PR TITLE
feat: render loading indicitor when caught up on feed

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -50,9 +50,21 @@ export default {
   },
   methods: {
     ...mapActions(["setNewsFeed"]),
+    cachedFeedHasUnreadItems() {
+      return (this.newsFeed.itemsCache || []).some(
+        cachedItem => !cachedItem.isRead,
+      );
+    },
     getFeeds() {
       if (this.feedItems.length) {
         this.backgroundLoading = true;
+
+        if (
+          !this.cachedFeedHasUnreadItems() &&
+          this.newsFeed.shouldFilterUnread
+        ) {
+          this.loading = true;
+        }
       } else {
         this.loading = true;
       }


### PR DESCRIPTION
These changes render a loading skeleton when fetching new items and a user is:
- caught up on their feed (all items are "read")
- filtering for unread items